### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,8 @@ jobs:
         with:
           node-version: 18
           cache: "npm"
-      - name: Install dependencies
-        run: npm install
       - name: Build
-        run: |
-          wasm-pack build
-          npm run build
+        run: npm run full-build
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: "Build node"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: |
+          wasm-pack build
+          npm run build
+  lint:
+    runs-on: ubuntu-latest
+
+    name: "Lint on ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+      - name: Install dependencies
+        run: npm install
+      - name: Lint & check formatting
+        run: npm run rome-ci

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"format": "rome format .",
 		"lint:fix": "rome check --apply .",
 		"lint:fix-suggested": "rome check --apply-suggested .",
-		"format:fix": "rome format --write ."
+		"format:fix": "rome format --write .",
+		"rome-ci": "rome ci ."
 	},
 	"devDependencies": {
 		"@types/lz-string": "^1.3.34",

--- a/script/complete.ts
+++ b/script/complete.ts
@@ -5,9 +5,7 @@ var completer = wasm.Playground.new(); // ~9ms
 // To keep the load down. If the inspection has already been turned around, it will be finished.
 var suggest_on_running = false;
 
-export function dir(
-	range: monaco.IRange,
-): monaco.languages.CompletionItem[] {
+export function dir(range: monaco.IRange): monaco.languages.CompletionItem[] {
 	let vars: wasm.ErgVarEntry[] = completer.dir();
 	return vars.map((ent) => {
 		return {

--- a/script/config.ts
+++ b/script/config.ts
@@ -26,7 +26,8 @@ export function set_dark(app: Application) {
 	if (css === null) {
 		let css = document.createElement("style");
 		css.id = "dark-css";
-		css.appendChild(document.createTextNode(`
+		css.appendChild(
+			document.createTextNode(`
 .tree-entry {
 	color: #dbdbdb!important;
 }
@@ -36,7 +37,8 @@ export function set_dark(app: Application) {
 .tree-entry:not(:last-child) {
 	border-bottom: 1px solid #343434;
 }
-`));
+`),
+		);
 		document.body.appendChild(css);
 	}
 }
@@ -64,7 +66,9 @@ export function set_light(app: Application) {
 		.classList.remove("has-background-black-ter");
 	document.getElementById("editor")!.style.border = "1px solid #ccc";
 	let dark_css = document.getElementById("dark-css");
-	if (dark_css != null) { document.body.removeChild(dark_css); }
+	if (dark_css != null) {
+		document.body.removeChild(dark_css);
+	}
 }
 
 export class ConfigModal {
@@ -258,7 +262,9 @@ export class ConfigModal {
 		menu.appendChild(section);
 		modal_content.appendChild(menu);
 		modal.appendChild(modal_content);
-		this.config_btn = document.getElementById("config-button") as HTMLButtonElement;
+		this.config_btn = document.getElementById(
+			"config-button",
+		) as HTMLButtonElement;
 		this.config_btn.addEventListener("click", function () {
 			modal.classList.add("is-active");
 		});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
 	plugins: [
 		new HtmlWebPackPlugin({
 			title: "Erg Web IDE",
-			template: 'script/index.html'
+			template: "script/index.html",
 		}),
 	],
 };


### PR DESCRIPTION
Added CI configuration. This PR includes the following changes:

- Add `ci.yml` for CI.
- Use `rome ci .`: this command will execute `lint` and `format`. If Rome detected any error, it'll set a result as "failure" (looks `lint` and `format` themselves will mark the result as successful even if it failed).
- Applied Rome's formatter.

@mtshiba 